### PR TITLE
Feature/more store rest tests

### DIFF
--- a/satel_shopify/store.py
+++ b/satel_shopify/store.py
@@ -1,4 +1,5 @@
 from asyncio import sleep
+from math import floor
 from time import monotonic
 from typing import Any, Dict, Optional
 
@@ -67,7 +68,7 @@ class Store:
     def __add_new_tokens(self):
         now = monotonic()
         time_since_update = now - self.updated_at
-        new_tokens = time_since_update * self.rate
+        new_tokens = floor(time_since_update * self.rate)
         if new_tokens > 1:
             self.tokens = min(self.tokens + new_tokens, self.max_tokens)
             self.updated_at = now

--- a/satel_shopify/store.py
+++ b/satel_shopify/store.py
@@ -2,7 +2,7 @@ from asyncio import sleep
 from time import monotonic
 from typing import Any, Dict, Optional
 
-from httpx import AsyncClient
+from httpx import AsyncClient, Response
 from loguru import logger
 from tenacity import retry
 from tenacity.retry import retry_if_exception
@@ -71,14 +71,14 @@ class Store:
             self.tokens = min(self.tokens + new_tokens, self.max_tokens)  # type: ignore
             self.updated_at = now
 
-    async def __handle_error(self, debug: str, endpoint: str, response):
+    async def __handle_error(self, debug: str, endpoint: str, response: Response):
         """Handle any error that occured when calling Shopify
 
         If the response has a valid json then return it too.
         """
         msg = (
             f'ERROR in store {self.name}: {debug}\n'
-            f'API response code: {response.status}\n'
+            f'API response code: {response.status_code}\n'
             f'API endpoint: {endpoint}\n'
         )
         try:
@@ -88,7 +88,7 @@ class Store:
         else:
             msg += f'API response json: {jresp}\n'
 
-        if 400 <= response.status < 500:
+        if 400 <= response.status_code < 500:
             # This appears to be our fault
             raise ShopifyCallInvalidError(msg)
 

--- a/satel_shopify/store.py
+++ b/satel_shopify/store.py
@@ -58,9 +58,10 @@ class Store:
         self.rate = RATE
 
     async def __wait_for_token(self):
+        self.__add_new_tokens()
         while self.tokens <= 1:
-            self.__add_new_tokens()
             await sleep(1)
+            self.__add_new_tokens()
         self.tokens -= 1
 
     def __add_new_tokens(self):
@@ -68,7 +69,7 @@ class Store:
         time_since_update = now - self.updated_at
         new_tokens = time_since_update * self.rate
         if new_tokens > 1:
-            self.tokens = min(self.tokens + new_tokens, self.max_tokens)  # type: ignore
+            self.tokens = min(self.tokens + new_tokens, self.max_tokens)
             self.updated_at = now
 
     async def __handle_error(self, debug: str, endpoint: str, response: Response):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -114,10 +114,11 @@ async def test_store_graphql_badquery(mocker):
         name
       }
     }'''
+    error_msg = "Field 'shopp' doesn't exist on type 'QueryRoot'"
     gql_response = {
         'errors': [
             {
-                'message': "Field 'shopp' doesn't exist on type 'QueryRoot'",
+                'message': error_msg,
                 'locations': [{'line': 2, 'column': 3}],
                 'path': ['query', 'shopp'],
                 'extensions': {
@@ -135,8 +136,9 @@ async def test_store_graphql_badquery(mocker):
         return_value=MockHTTPResponse(status_code=200, jsondata=gql_response),
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as e:
         await store.execute_gql(query=query)
+    assert str(e.value) == f'GraphQL query is incorrect:\n{error_msg}'
 
     shopify_request_mock.assert_called_once()
 


### PR DESCRIPTION
Add more Rest tests and also GraphQL tests.
Fixed and improved the code at the same time.

API change: The GraphQL method now returns the content of the `data` field rather than the whole response payload since handling the rest of the payload should be abstracted away in the `execute_gql` method.